### PR TITLE
Remove hardcoded DashScope API keys

### DIFF
--- a/ApexOracle/DataPrepare/discription_generation_w_ATCC.py
+++ b/ApexOracle/DataPrepare/discription_generation_w_ATCC.py
@@ -6,10 +6,13 @@ import copy
 from tqdm import tqdm
 
 current_directory = Path(__file__).parent
+dashscope_api_key = os.getenv("DASHSCOPE_API_KEY")
+
+if not dashscope_api_key:
+    raise EnvironmentError("DASHSCOPE_API_KEY environment variable is required.")
 
 client = OpenAI(
-    # 若没有配置环境变量，请用百炼API Key将下行替换为：api_key="sk-xxx",
-    api_key='sk-9f5650f9e4464e07a82a5a73035805c3',  # TODO: 记得清除 API key
+    api_key=dashscope_api_key,
     base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",  # 填写DashScope服务的base_url
 )
 

--- a/ApexOracle/DataPrepare/discription_generation_wo_ATCC.py
+++ b/ApexOracle/DataPrepare/discription_generation_wo_ATCC.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 import argparse
 import json
@@ -347,9 +348,13 @@ counts_sorted = count[sorted_indices]
 
 # np.savetxt(current_directory / 'Data' / "original_names_in_DBAASP_wo_ATCC.txt", unique_elements_sorted, fmt='%s')
 
+dashscope_api_key = os.getenv("DASHSCOPE_API_KEY")
+
+if not dashscope_api_key:
+    raise EnvironmentError("DASHSCOPE_API_KEY environment variable is required.")
+
 client = OpenAI(
-    # 若没有配置环境变量，请用百炼API Key将下行替换为：api_key="sk-xxx",
-    api_key='sk-325b8ad3d9624c778c31a34245ea202b',  # TODO: 记得清除 API key
+    api_key=dashscope_api_key,
     base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",  # 填写DashScope服务的base_url
 )
 

--- a/ApexOracle/DataPrepare/get_synergy_Evo.py
+++ b/ApexOracle/DataPrepare/get_synergy_Evo.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from typing import List, Any
 import requests
@@ -212,9 +213,13 @@ for strain in non_overlap_strains:
 print(bateria_strains)
 
 # 看一下这些不同的 strain 是不是都有相对应的 description
+dashscope_api_key = os.getenv("DASHSCOPE_API_KEY")
+
+if not dashscope_api_key:
+    raise EnvironmentError("DASHSCOPE_API_KEY environment variable is required.")
+
 client = OpenAI(
-    # 若没有配置环境变量，请用百炼API Key将下行替换为：api_key="sk-xxx",
-    api_key='sk-325b8ad3d9624c778c31a34245ea202b',  # TODO: 记得清除 API key
+    api_key=dashscope_api_key,
     base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",  # 填写DashScope服务的base_url
 )
 for strain in bateria_strains:


### PR DESCRIPTION
## Summary
- replace hardcoded DashScope API keys with environment-driven configuration
- validate presence of the DASHSCOPE_API_KEY variable before initializing OpenAI clients

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694217ccaef0832e9507a4f13ce86e54)