### PR TITLE
Add the validated Evo2 module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "modules/generation"]
 	path = modules/generation
 	url = https://github.com/DragonDescentZerotsu/ApexOracle-Generation.git
+[submodule "modules/evo2"]
+	path = modules/evo2
+	url = https://github.com/DragonDescentZerotsu/ApexOracle-Evo2.git

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ bootstrap checks, and cross-module quickstarts.
 
 ## Current release status
 
-The in-place conversion from the historical monorepo has started. Two validated modules are currently locked:
+The in-place conversion from the historical monorepo has started. Three validated modules are currently locked:
 
 | Module | Role | Locked commit |
 | --- | --- | --- |
 | [ApexOracle-MDLM](https://github.com/DragonDescentZerotsu/ApexOracle-MDLM) | downstream embedding, guidance heads, and candidate scoring | `c9d17c7` |
+| [ApexOracle-Evo2](https://github.com/DragonDescentZerotsu/ApexOracle-Evo2) | record-aware genome embedding extraction | `2184211` |
 | [ApexOracle-Generation](https://github.com/DragonDescentZerotsu/ApexOracle-Generation) | guided discrete diffusion and remasking | `de6c1e5` |
 
-Core, DLM-Pretraining, and Evo-2 remain explicitly `pending` in `manifests/modules.lock.yaml`; no floating or placeholder
+Core and DLM-Pretraining remain explicitly `pending` in `manifests/modules.lock.yaml`; no floating or placeholder
 gitlinks are published for them. This repository is therefore a conversion candidate, not yet the final paper release.
 
 ## Clone
@@ -42,7 +43,7 @@ ApexOracle/
 │   ├── core/             # existing Synergy repository, later renamed ApexOracle-Core
 │   ├── dlm_pretrain/     # collaborator DLM + MTR producer
 │   ├── mdlm/             # ready
-│   ├── evo2/             # pending clean fork
+│   ├── evo2/             # ready
 │   └── generation/       # ready
 ├── quickstarts/
 ├── environments/

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -7,14 +7,15 @@
 - The legacy tree is recoverable from branch `legacy-monorepo` and annotated tag
   `legacy-monorepo-snapshot-2026-08-10`.
 - `ApexOracle-MDLM` is locked to `c9d17c7f6f091234aaaebf5f08dbe23542f980c1`.
+- `ApexOracle-Evo2` is locked to `2184211acda07b0d5ca865067174ac42f530ad04`; its CPU contracts, package
+  archives, remote CI, and Evo2-40B extraction runtime smoke have passed.
 - `ApexOracle-Generation` is locked to `de6c1e590c25b2ce36b4ce5c42c5a4fa0dcc7705`.
 - The root repository contains no model weights, embeddings, datasets, or raw experiment outputs after conversion.
 
 ## Pending module gates
 
-1. **Evo-2:** prepare a license-compatible clean fork, parameterized genome-extraction CLI, and tensor-contract smoke.
-2. **DLM-Pretraining:** extract the collaborator producer with minimal changes and run synthetic train/save/load smoke.
-3. **Core:** finish the current Synergy work, audit the full Git history for private data/credentials/large blobs, then
+1. **DLM-Pretraining:** extract the collaborator producer with minimal changes and run synthetic train/save/load smoke.
+2. **Core:** finish the current Synergy work, audit the full Git history for private data/credentials/large blobs, then
    rename that same repository to `ApexOracle-Core` and decide public visibility.
 
 Pending modules are intentionally absent from `.gitmodules`. Their target URLs and `null` commits are recorded in

--- a/manifests/modules.lock.yaml
+++ b/manifests/modules.lock.yaml
@@ -26,9 +26,9 @@
     {
       "id": "evo2",
       "path": "modules/evo2",
-      "status": "pending",
+      "status": "ready",
       "url": "https://github.com/DragonDescentZerotsu/ApexOracle-Evo2.git",
-      "commit": null
+      "commit": "2184211acda07b0d5ca865067174ac42f530ad04"
     },
     {
       "id": "generation",

--- a/quickstarts/README.md
+++ b/quickstarts/README.md
@@ -1,5 +1,21 @@
 # Quickstarts
 
+## Genome embedding extraction
+
+Install the fixed Evo2 module in its documented environment, then inspect the deterministic extraction plan without
+loading model weights:
+
+```bash
+python -m pip install -e modules/evo2
+apexoracle-evo2-extract --input path/to/genomes --output-dir embeddings --plan-only
+```
+
+Remove `--plan-only` to run extraction with the module's default Evo2-40B profile. File inputs and flat directories of
+FASTA files are supported; tensors and JSON provenance manifests are written together. See
+`modules/evo2/README.md` for model, layer, window, device, and batching options.
+
+## End-to-end prediction and generation
+
 Two root quickstarts are planned:
 
 1. predict MIC for one public molecule and known strain using fixed Core/MDLM commits;

--- a/tests/test_module_locks.py
+++ b/tests/test_module_locks.py
@@ -17,9 +17,12 @@ def test_module_lock_checker_passes():
     )
     summary = json.loads(completed.stdout)
     assert summary["status"] == "passed"
-    assert summary["ready_modules"] == ["modules/generation", "modules/mdlm"]
+    assert summary["ready_modules"] == [
+        "modules/evo2",
+        "modules/generation",
+        "modules/mdlm",
+    ]
     assert summary["pending_modules"] == [
         "modules/core",
         "modules/dlm_pretrain",
-        "modules/evo2",
     ]


### PR DESCRIPTION
## Summary
- add the validated ApexOracle-Evo2 submodule at its fixed release commit
- mark Evo2 ready in the module lock and publish the genome extraction quickstart
- update release-status assertions for three ready modules

## Validation
- python scripts/check_release_tree.py
- python scripts/check_module_locks.py
- python -m pytest -q
- git diff --check

The module remains independently versioned and no data, model weights, or raw outputs are added to the super-repository.