### PR TITLE
Add the validated DLM pretraining module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "modules/evo2"]
 	path = modules/evo2
 	url = https://github.com/DragonDescentZerotsu/ApexOracle-Evo2.git
+[submodule "modules/dlm_pretrain"]
+	path = modules/dlm_pretrain
+	url = https://github.com/DragonDescentZerotsu/ApexOracle-DLM-Pretraining.git

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ bootstrap checks, and cross-module quickstarts.
 
 ## Current release status
 
-The in-place conversion from the historical monorepo has started. Three validated modules are currently locked:
+The in-place conversion from the historical monorepo has started. Four validated modules are currently locked:
 
 | Module | Role | Locked commit |
 | --- | --- | --- |
+| [ApexOracle-DLM-Pretraining](https://github.com/DragonDescentZerotsu/ApexOracle-DLM-Pretraining) | collaborator-developed DLM + 209-descriptor MTR producer | `362ffcc` |
 | [ApexOracle-MDLM](https://github.com/DragonDescentZerotsu/ApexOracle-MDLM) | downstream embedding, guidance heads, and candidate scoring | `c9d17c7` |
 | [ApexOracle-Evo2](https://github.com/DragonDescentZerotsu/ApexOracle-Evo2) | record-aware genome embedding extraction | `2184211` |
 | [ApexOracle-Generation](https://github.com/DragonDescentZerotsu/ApexOracle-Generation) | guided discrete diffusion and remasking | `de6c1e5` |
 
-Core and DLM-Pretraining remain explicitly `pending` in `manifests/modules.lock.yaml`; no floating or placeholder
-gitlinks are published for them. This repository is therefore a conversion candidate, not yet the final paper release.
+Core remains explicitly `pending` in `manifests/modules.lock.yaml`; no floating or placeholder gitlink is published
+for it. This repository is therefore a conversion candidate, not yet the final paper release.
 
 ## Clone
 
@@ -41,7 +42,7 @@ submodule. Model weights and datasets are never stored as Git objects; released 
 ApexOracle/
 ├── modules/
 │   ├── core/             # existing Synergy repository, later renamed ApexOracle-Core
-│   ├── dlm_pretrain/     # collaborator DLM + MTR producer
+│   ├── dlm_pretrain/     # ready collaborator DLM + MTR producer
 │   ├── mdlm/             # ready
 │   ├── evo2/             # ready
 │   └── generation/       # ready

--- a/docs/RELEASE_STATUS.md
+++ b/docs/RELEASE_STATUS.md
@@ -6,6 +6,9 @@
   is being created.
 - The legacy tree is recoverable from branch `legacy-monorepo` and annotated tag
   `legacy-monorepo-snapshot-2026-08-10`.
+- `ApexOracle-DLM-Pretraining` is locked to `362ffccac79bdd638a4e913c4f17df613da18f36`; its original source
+  recovery tag, 56-file manifest, source contracts, remote CI, fresh clone, and H100 joint-objective train/save/load
+  smoke have passed.
 - `ApexOracle-MDLM` is locked to `c9d17c7f6f091234aaaebf5f08dbe23542f980c1`.
 - `ApexOracle-Evo2` is locked to `2184211acda07b0d5ca865067174ac42f530ad04`; its CPU contracts, package
   archives, remote CI, and Evo2-40B extraction runtime smoke have passed.
@@ -14,11 +17,10 @@
 
 ## Pending module gates
 
-1. **DLM-Pretraining:** extract the collaborator producer with minimal changes and run synthetic train/save/load smoke.
-2. **Core:** finish the current Synergy work, audit the full Git history for private data/credentials/large blobs, then
+1. **Core:** finish the current Synergy work, audit the full Git history for private data/credentials/large blobs, then
    rename that same repository to `ApexOracle-Core` and decide public visibility.
 
-Pending modules are intentionally absent from `.gitmodules`. Their target URLs and `null` commits are recorded in
+The pending module is intentionally absent from `.gitmodules`. Its target URL and `null` commit are recorded in
 `manifests/modules.lock.yaml` so incomplete work cannot look release-ready.
 
 ## Final release gates

--- a/manifests/modules.lock.yaml
+++ b/manifests/modules.lock.yaml
@@ -12,9 +12,9 @@
     {
       "id": "dlm_pretraining",
       "path": "modules/dlm_pretrain",
-      "status": "pending",
+      "status": "ready",
       "url": "https://github.com/DragonDescentZerotsu/ApexOracle-DLM-Pretraining.git",
-      "commit": null
+      "commit": "362ffccac79bdd638a4e913c4f17df613da18f36"
     },
     {
       "id": "mdlm",

--- a/tests/test_module_locks.py
+++ b/tests/test_module_locks.py
@@ -18,11 +18,11 @@ def test_module_lock_checker_passes():
     summary = json.loads(completed.stdout)
     assert summary["status"] == "passed"
     assert summary["ready_modules"] == [
+        "modules/dlm_pretrain",
         "modules/evo2",
         "modules/generation",
         "modules/mdlm",
     ]
     assert summary["pending_modules"] == [
         "modules/core",
-        "modules/dlm_pretrain",
     ]


### PR DESCRIPTION
## Summary

- add the collaborator-developed DLM plus MTR pretraining producer at its fixed v0.1.0 commit
- mark DLM-Pretraining ready in the module lock and release status
- leave Core as the only pending submodule

## Validation

- release-tree checker passed
- module-lock checker passed with four ready modules
- root tests passed
- recursive submodule status matches the fixed commit
- git diff check passed

No dataset, checkpoint, tokenizer asset, cache, or training output is added to the super-repository.